### PR TITLE
Correct "Open Data Folder" behaviour

### DIFF
--- a/src/Mockingbird/UI/View/OptionsView.swift
+++ b/src/Mockingbird/UI/View/OptionsView.swift
@@ -46,7 +46,7 @@ public class OptionsView {
 
                     LargeButton("OPEN DATA FOLDER") {
 
-                        Util.openFinder(with: Default.Folder.main)
+                        Util.openFinder(with: Default.Folder.workingDirectory)
                     }
 
                     LargeButton("DOCUMENTATION") {


### PR DESCRIPTION
# PR Details

Correct behaviour for the "Open Data Folder" button on the settings screen after the changes made to the working directory

## Description

When pressing the "Open Data Folder", Mockingbird now opens the working directory instead of its main directory as it was previously

## Motivation and Context

Correct behaviour that was incorrect after the changes in 1.2.0

## How Has This Been Tested

Ran the Mockingbird app and tested the behaviour before and after the changes

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)