### PR TITLE
Intercept requests based on context paths

### DIFF
--- a/src/Mockingbird.xcodeproj/project.pbxproj
+++ b/src/Mockingbird.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		216DC9708C747E4014C763B8 /* Pods_Mockingbird.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4287C41673FEE0A7D53CFC08 /* Pods_Mockingbird.framework */; };
 		737203AC4CFCF605F6FF30D3 /* Pods_MockingbirdTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8952BC9226AA3B164321E36D /* Pods_MockingbirdTests.framework */; };
 		8F56D1E2265E7139005159E1 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F56D1E1265E7139005159E1 /* Configuration.swift */; };
+		8F8592612722DCAA001F55E6 /* mitm_on.sh in Resources */ = {isa = PBXBuildFile; fileRef = 8F8592602722DCAA001F55E6 /* mitm_on.sh */; };
 		B63AA30E2469D15200D6026B /* ServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63AA30D2469D15200D6026B /* ServerTests.swift */; };
 		B63AA3102469D76D00D6026B /* UtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63AA30F2469D76D00D6026B /* UtilTests.swift */; };
 		B640167E245B50FF009EDBBF /* DataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B640167D245B50FF009EDBBF /* DataHelper.swift */; };
@@ -120,6 +121,7 @@
 		83BCB3BAD6AC4B8D47908BEF /* Pods-Mockingbird-MockingbirdUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Mockingbird-MockingbirdUITests.release.xcconfig"; path = "Target Support Files/Pods-Mockingbird-MockingbirdUITests/Pods-Mockingbird-MockingbirdUITests.release.xcconfig"; sourceTree = "<group>"; };
 		8952BC9226AA3B164321E36D /* Pods_MockingbirdTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MockingbirdTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F56D1E1265E7139005159E1 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		8F8592602722DCAA001F55E6 /* mitm_on.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = mitm_on.sh; sourceTree = "<group>"; };
 		95E8B10A50D0E77C0D935628 /* Pods-MockingbirdTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MockingbirdTests.release.xcconfig"; path = "Target Support Files/Pods-MockingbirdTests/Pods-MockingbirdTests.release.xcconfig"; sourceTree = "<group>"; };
 		B63AA30D2469D15200D6026B /* ServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerTests.swift; sourceTree = "<group>"; };
 		B63AA30F2469D76D00D6026B /* UtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilTests.swift; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 			children = (
 				B6736B5A239923230040B29D /* ip_info.sh */,
 				B6736B5B239923230040B29D /* mitm_off.sh */,
+				8F8592602722DCAA001F55E6 /* mitm_on.sh */,
 				B6736B58239923230040B29D /* proxy_off.sh */,
 				B6736B5C239923230040B29D /* proxy_on.sh */,
 				B68F436B23CF5BD900D4B69C /* proxy_wifi_on.sh */,
@@ -799,6 +802,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8F8592612722DCAA001F55E6 /* mitm_on.sh in Resources */,
 				B652677A25619D8A000B1E34 /* mitmdump_mb.zip in Resources */,
 				B68F436C23CF5BD900D4B69C /* proxy_wifi_on.sh in Resources */,
 				B6736B1523981D320040B29D /* Assets.xcassets in Resources */,

--- a/src/Mockingbird/Resources/Scripts/mitm_on.sh
+++ b/src/Mockingbird/Resources/Scripts/mitm_on.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ -z "$2" ]
+then
+    ~/.mockingbird/mitmproxy/mitmdump_mb
+else
+    ~/.mockingbird/mitmproxy/mitmdump_mb --allow-hosts "$2"
+fi

--- a/src/Mockingbird/Store/Server/Service/ServerManager.swift
+++ b/src/Mockingbird/Store/Server/Service/ServerManager.swift
@@ -61,19 +61,6 @@ private extension ServerManager {
 
                 var transaction = try ServerTransaction(text)
 
-                if let context = ContextManager.shared.currentContext {
-
-                    let urlStr = transaction.request.url.absoluteString
-                    let exist = context.paths.filter { urlStr.contains($0) }.count != 0
-
-                    if !exist {
-
-                        _log(type: .info, log: "blocked: \(urlStr)")
-                        session.writeText(text)
-                        return
-                    }
-                }
-
                 let pattern = Router.shared.convertUrlToPattern(transaction.request.url)
 
                 let (code, ret) = Router.shared.handler(for: transaction.request.url, type: transaction.request.method)

--- a/src/Mockingbird/Store/Server/Service/ServerManager.swift
+++ b/src/Mockingbird/Store/Server/Service/ServerManager.swift
@@ -70,18 +70,17 @@ private extension ServerManager {
 
                     self.handle(transaction: transaction, pattern: pattern, mocked: true, isMock: false, original: text)
 
-                    if transaction.response.statusCode != 200 {
-
-                        transaction.response.headers.append(["Content-Type", "application/json; charset=utf-8"])
-                        transaction.response.headers.append(["Content-Encoding", "gzip"])
-                        transaction.response.headers.append(["Content-Language", "en-GB"])
-                    }
-
                     let textMinify = ret.minify
                     transaction.response.statusCode = code
                     transaction.response.body = textMinify
                     transaction.response.headers.removeAll { $0[0] == "Content-Length" }
                     transaction.response.headers.append(["Content-Length", "\(ret.count)"])
+                    transaction.response.headers.removeAll { $0[0] == "Content-Type" }
+                    transaction.response.headers.append(["Content-Type", "application/json; charset=utf-8"])
+                    transaction.response.headers.removeAll { $0[0] == "Content-Encoding" }
+                    transaction.response.headers.append(["Content-Encoding", "gzip"])
+                    transaction.response.headers.removeAll { $0[0] == "Content-Language" }
+                    transaction.response.headers.append(["Content-Language", "en-GB"])
 
                     self.handle(transaction: transaction, pattern: pattern, mocked: false, isMock: true, original: textMinify)
 

--- a/src/Mockingbird/Store/Task/Service/ProcessManager.swift
+++ b/src/Mockingbird/Store/Task/Service/ProcessManager.swift
@@ -18,10 +18,6 @@ final class ProcessManager {
 
         switch process {
 
-        case .mitmOn:
-
-            ProcessTask.runAsync(process: process, callback: self)
-
         case .ipInfo:
 
             ProcessTask.launchSync(process: process, callback: self)

--- a/src/Mockingbird/Store/Task/Service/ProcessManager.swift
+++ b/src/Mockingbird/Store/Task/Service/ProcessManager.swift
@@ -24,7 +24,9 @@ final class ProcessManager {
 
         default:
 
-            ProcessTask.launchAsync(process: process, callback: self)
+            ProcessTask.launchAsync(process: process,
+                                    currentContext: ContextManager.shared.currentContext,
+                                    callback: self)
         }
     }
 }

--- a/src/Mockingbird/Store/Task/Service/ProcessManager.swift
+++ b/src/Mockingbird/Store/Task/Service/ProcessManager.swift
@@ -25,7 +25,6 @@ final class ProcessManager {
         default:
 
             ProcessTask.launchAsync(process: process,
-                                    currentContext: ContextManager.shared.currentContext,
                                     callback: self)
         }
     }

--- a/src/Mockingbird/Store/Task/Service/ProcessTask.swift
+++ b/src/Mockingbird/Store/Task/Service/ProcessTask.swift
@@ -22,7 +22,7 @@ enum ProcessType {
     case proxyOn
     case proxyWifiOn
     case proxyOff
-    case mitmOn
+    case mitmOn(currentContext: ServerContextInfo?)
     case mitmOff
     case ipInfo
 
@@ -79,7 +79,6 @@ class ProcessTask {
     }
 
     static func launchAsync(process: ProcessType,
-                            currentContext: ServerContextInfo?,
                             callback: ProcessTaskCallback?) {
 
         guard let script = Bundle.main.path(forResource: process.script, ofType: "sh") else { return }
@@ -91,7 +90,12 @@ class ProcessTask {
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
 
-            let contextHosts = currentContext?.paths.joined(separator: "|") ?? ""
+            var contextHosts = ""
+
+            if case .mitmOn(let currentContext) = process {
+
+                contextHosts = currentContext?.paths.joined(separator: "|") ?? ""
+            }
 
             let task = Process()
             task.launchPath = "/bin/sh"

--- a/src/Mockingbird/Store/Task/Service/ProcessTask.swift
+++ b/src/Mockingbird/Store/Task/Service/ProcessTask.swift
@@ -78,7 +78,9 @@ class ProcessTask {
         }
     }
 
-    static func launchAsync(process: ProcessType, callback: ProcessTaskCallback?) {
+    static func launchAsync(process: ProcessType,
+                            currentContext: ServerContextInfo?,
+                            callback: ProcessTaskCallback?) {
 
         guard let script = Bundle.main.path(forResource: process.script, ofType: "sh") else { return }
 
@@ -89,7 +91,7 @@ class ProcessTask {
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
 
-            let contextHosts = ContextManager.shared.currentContext?.paths.joined(separator: "|") ?? ""
+            let contextHosts = currentContext?.paths.joined(separator: "|") ?? ""
 
             let task = Process()
             task.launchPath = "/bin/sh"

--- a/src/Mockingbird/Store/Task/TaskReducer.swift
+++ b/src/Mockingbird/Store/Task/TaskReducer.swift
@@ -118,7 +118,7 @@ private extension TaskReducer {
 
         state.isMitmEnabled = true
 
-        ProcessManager.shared.execute(process: .mitmOn)
+        ProcessManager.shared.execute(process: .mitmOn(currentContext: ContextManager.shared.currentContext))
     }
 
     static func stopMitm(with state: inout TaskState) {

--- a/src/Mockingbird/UI/View/OptionsView.swift
+++ b/src/Mockingbird/UI/View/OptionsView.swift
@@ -22,6 +22,11 @@ public class OptionsView {
 
                     ContextManager.shared.setContext(index: val)
                 }
+
+                if AppStore.task.state.isMitmEnabled {
+                    Text("Please disable the server before changing the context")
+                }
+
                 NewLine()
 
                 Text("WORKING DIRECTORY: \(Default.Folder.workingDirectory)")


### PR DESCRIPTION
# PR Details

Up until now the mitmproxy was intercepting all network traffic which caused issues when trying to perform other network activities with Mockingbird activated.

With these changes, we'll leverage the `--allow-hosts` option to solely intercept requests with the path for the context selected. This will allow any user to use internet freely on their device when filtering requests according to their request

## Description

* Adds `mitm-on.sh` script to start the `mitmdump_mb` executable with the `--allow-hosts` option depending on the selected context status
* Removes filtering performed on `ContextManager` (no longer needed since this is being done at the mitmproxy level
* Adds label to alert the user to disable the Server before changing the context
* Removes `ProcessObject` and `runAsync` since we're no longer launching executables directly from the source code


## Motivation and Context

In our teams, a painpoint that we felt a lot was the loss of all network connection when we simply wanted to intercept requests based on a determined context.

## How Has This Been Tested

After applying these changes, I ran the Mockingbird app several times with no context applied or with context applied (with single or multiple paths). While in the first scenario all traffic is targeted and any activity using internet traffic is halted, in the second scenario only the traffic that is targeted by the context is intercepted and the user can work with the remaining activities.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] All new and existing tests passed.

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)